### PR TITLE
ignore cv_bridge and downstream due to wrong rosdep key

### DIFF
--- a/bouncy.ignored
+++ b/bouncy.ignored
@@ -1,0 +1,3 @@
+cv_bridge
+opencv_tests
+vision_opencv


### PR DESCRIPTION
@gaoethan FYI: once the rosdep keys have been fixed this file can be removed and a new release be made